### PR TITLE
Fix array copy crash when beginning line exceeds number of lines.

### DIFF
--- a/org.spoofax.sunshine/src/org/metaborg/sunshine/model/messages/CodeRegionHelper.java
+++ b/org.spoofax.sunshine/src/org/metaborg/sunshine/model/messages/CodeRegionHelper.java
@@ -10,8 +10,12 @@ public class CodeRegionHelper {
 	public static final char NEWLINE = '\n';
 
 	public static String[] getAffectedLines(String input, int beginLine, int endLine) {
-		if (input.length() > 0 && beginLine > 0 && endLine > 0)
-			return Arrays.copyOfRange(input.split("\\r?\\n"), beginLine - 1, endLine);
+		if (input.length() > 0 && beginLine > 0 && endLine > 0) {
+			final String[] lines = input.split("\\r?\\n");
+			if (beginLine - 1 > lines.length)
+				return new String[0];
+			return Arrays.copyOfRange(lines, beginLine - 1, endLine);
+		}
 		else
 			return new String[0];
 	}


### PR DESCRIPTION
Fixes an out of bounds exception where the number of lines (in `lines`) is lower than `beginLine`.
