### PR TITLE
Un-hide the build transform-filter option

### DIFF
--- a/org.metaborg.sunshine2/src/main/java/org/metaborg/sunshine/command/base/BuildCommand.java
+++ b/org.metaborg.sunshine2/src/main/java/org/metaborg/sunshine/command/base/BuildCommand.java
@@ -50,7 +50,7 @@ public abstract class BuildCommand implements ICommand {
     @Parameter(names = { "-T", "--no-transform" }, description = "Disables transformation")
     private boolean noTransform;
 
-    @Parameter(names = { "-t", "--transform-filter" }, hidden = true, 
+    @Parameter(names = { "-t", "--transform-filter" },
         description = "Regex filter for filtering which files get transformed")
     private String transformFilterRegex;
 


### PR DESCRIPTION
If [https://github.com/metaborg/spoofax/pull/34](https://github.com/metaborg/spoofax/pull/34) is merged then the `--transform-filter` option will behave as advertised and can be un-hidden.